### PR TITLE
Fix typo in logs

### DIFF
--- a/auth/src/index.ts
+++ b/auth/src/index.ts
@@ -20,7 +20,7 @@ const start = async () => {
     const PORT = 3000 || process.env.PORT;
 
     app.listen(PORT, () => {
-        console.log(`App is listening on porta: ${PORT} !`);
+        console.log(`App is listening on port: ${PORT} !`);
     });
 };
 


### PR DESCRIPTION
Just found out that there is a misleading typo in one of the console.log statement. Fixed it.